### PR TITLE
Use `inet:parse_address/1` to parse the IP address

### DIFF
--- a/src/hstub_cc_handler.erl
+++ b/src/hstub_cc_handler.erl
@@ -126,13 +126,10 @@ parse_request(Req) ->
 
 ip_to_tuple(IP) when is_binary(IP) ->
     IPs = binary_to_list(IP),
-    case string:tokens(IPs, ".") of
-        [A,B,C,D] ->
-            {list_to_integer(A),
-             list_to_integer(B),
-             list_to_integer(C),
-             list_to_integer(D)};
-        _ ->
+    case inet:parse_address(IPs) of
+        {ok, Parsed} ->
+            Parsed;
+        {error, einval} ->
             IPs
     end.
 


### PR DESCRIPTION
Use `inet:parse_address/1` to parse the IP address to the tuple representation of the IP address. Works for IPv4 and IPv6.
