### PR TITLE
Add a possibility to return statistics from the lookup function.

### DIFF
--- a/src/hstub_interface.erl
+++ b/src/hstub_interface.erl
@@ -6,13 +6,15 @@
 -type queue_length() :: non_neg_integer().
 -type wait_time() :: non_neg_integer().
 -type service_backend() :: {inet:ip_address(), inet:port_number()}.
+-type lookup_stats() :: [{atom(), term()}]|[].
 
 -export_type([domain/0,
               domain_group/0,
               service/0,
               queue_length/0,
               wait_time/0,
-              service_backend/0]).
+              service_backend/0,
+              lookup_stats/0]).
 
 -callback lookup_domain_name(Domain) ->
     {error, not_found} |
@@ -22,7 +24,7 @@
       Reason :: atom().
 
 -callback lookup_service(domain_group()) ->
-    {route, service()} |
+    {route, service(), lookup_stats()} |
     {error, no_route_id} |
     {error, {backlog_timeout, queue_length(), wait_time()}} |
     {error, {backlog_too_deep, queue_length(), wait_time()}} |

--- a/src/hstub_lookup_service_middleware.erl
+++ b/src/hstub_lookup_service_middleware.erl
@@ -10,7 +10,7 @@ execute(Req, Env) ->
     {Service, Req2} = ?LOG(service_lookup, InterfaceModule:lookup_service(DomainGroup), Req1),
     handle_service(Service, Req2, Env).
 
-handle_service({route, Service}, Req, Env) ->
+handle_service({route, Service, _Stats}, Req, Env) ->
     % We have a service to route to, moving on
     Req1 = cowboy_req:set_meta(service, Service, Req),
     {ok, Req1, Env};

--- a/src/hstub_stub.erl
+++ b/src/hstub_stub.erl
@@ -18,7 +18,7 @@ lookup_domain_name(_Domain) ->
     {ok, domain_group}.
 
 -spec lookup_service(DomainGroup) ->
-                            {route, Service} |
+                            {route, Service, LookupStats} |
                             {error, no_route_id} |
                             {error, {backlog_timeout, QueueLength,
                                      WaitTime}} |
@@ -38,9 +38,10 @@ lookup_domain_name(_Domain) ->
       DomainGroup :: hstub_interface:domain_group(),
       Service :: hstub_interface:service(),
       QueueLength :: hstub_interface:queue_length(),
-      WaitTime :: hstub_interface:wait_time().
+      WaitTime :: hstub_interface:wait_time(),
+      LookupStats :: hstub_interface:lookup_stats().
 lookup_service(_DomainGroup) ->
-    {route, service}.
+    {route, service, []}.
 
 -spec app_mode(DomainGroup) ->
                       normal_mode when

--- a/test/hstub_continue_SUITE.erl
+++ b/test/hstub_continue_SUITE.erl
@@ -13,7 +13,7 @@ all() -> [back_and_forth, body_timeout, non_terminal, continue_upgrade_httpbis,
 init_per_suite(Config) ->
     meck:new(hstub_stub, [passthrough, no_link]),
     meck:expect(hstub_stub, lookup_domain_name, fun(_) -> {ok, test_domain} end),
-    meck:expect(hstub_stub, lookup_service, fun(_) -> {route, test_service} end),
+    meck:expect(hstub_stub, lookup_service, fun(_) -> {route, test_service, []} end),
     Env = application:get_all_env(hstub),
     [{hstub_env, Env} | Config].
 

--- a/test/hstub_proxy_SUITE.erl
+++ b/test/hstub_proxy_SUITE.erl
@@ -187,7 +187,7 @@ mock_through(Port) ->
                 end),
     meck:expect(hstub_stub, lookup_service,
                 fun(_) ->
-                        {route, test_route}
+                        {route, test_route, []}
                 end),
     meck:expect(hstub_stub, service_backend,
                 fun(_) ->


### PR DESCRIPTION
This makes separation between hermes lookup code and hstub cleaner.
