### PR TITLE
Impose a maximal cookie length on responses

### DIFF
--- a/src/vegur_client.erl
+++ b/src/vegur_client.erl
@@ -82,6 +82,8 @@
           bytes_recv :: non_neg_integer() | undefined %% Bytes recv from downstream
 }).
 
+-define(MAX_COOKIE_LINE_SIZE, 8192). % in bytes
+
 -opaque client() :: #client{}.
 -export_type([client/0]).
 
@@ -432,6 +434,11 @@ stream_header(Client=#client{state=State, buffer=Buffer,
                                 true -> Client#client{connection=keepalive};
                                 false -> Client
                             end
+                    end;
+                <<"set-cookie">> ->
+                    case byte_size(Line) > ?MAX_COOKIE_LINE_SIZE of
+                        true -> {error, cookie_length};
+                        false -> Client
                     end;
                 _ ->
                     Client

--- a/src/vegur_stub.erl
+++ b/src/vegur_stub.erl
@@ -88,6 +88,8 @@ error_page(maintainance_mode, _DomainGroup, HandlerState) ->
     {{503, [], <<>>}, HandlerState};
 error_page(content_length, _DomainGroup, HandlerState) ->
     {{502, [], <<>>}, HandlerState};
+error_page(cookie_length, _DomainGroup, HandlerState) ->
+    {{502, [], <<>>}, HandlerState};
 error_page(empty_host, _DomainGroup, HandlerState) ->
     {{400, [], <<>>}, HandlerState};
 error_page(expectation_failed, _DomainGroup, HandlerState) ->

--- a/test/vegur_roundtrip_SUITE.erl
+++ b/test/vegur_roundtrip_SUITE.erl
@@ -16,7 +16,7 @@ groups() -> [{continue, [], [
                 duplicate_identical_lengths_req,
                 duplicate_different_lengths_resp, duplicate_csv_lengths_resp,
                 duplicate_identical_lengths_resp,
-                delete_hop_by_hop
+                delete_hop_by_hop, response_header_line_limits
              ]},
              {http_1_0, [], [
                 advertise_1_1, conn_close_default, conn_keepalive_opt,
@@ -530,6 +530,30 @@ delete_hop_by_hop(Config) ->
     nomatch = re:run(RecvClient, "^proxy-authorization:", [global,multiline,caseless]),
     {match,_} = re:run(RecvClient, "^proxy-authentication:", [global,multiline,caseless]).
 
+
+response_header_line_limits(Config) ->
+    %% Expect at least 8192 bytes allowed for each header line, but don't
+    %% allow more for cookies, because this can be used in a DoS with shared
+    %% domains. We're otherwise extremely permissive on this front.
+    IP = ?config(server_ip, Config),
+    Port = ?config(proxy_port, Config),
+    Req = req(Config),
+    Resp = resp_cookies(8193),
+    %% Open the server to listening. We then need to send data for the
+    %% proxy to get the request and contact a back-end
+    Ref = make_ref(),
+    start_acceptor(Ref, Config),
+    {ok, Client} = gen_tcp:connect(IP, Port, [{active,false},list],1000),
+    ok = gen_tcp:send(Client, Req),
+    %% Fetch the server socket
+    Server = get_accepted(Ref),
+    %% Exchange all the data
+    {ok, _} = gen_tcp:recv(Server, 0, 1000),
+    ok = gen_tcp:send(Server, Resp),
+    {ok, RecvClient} = gen_tcp:recv(Client, 0, 1000),
+    %% Final response checking
+    {match,_} = re:run(RecvClient, "502", [global,multiline]).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% HTTP 1.0 BEHAVIOUR %%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -996,6 +1020,16 @@ resp_hops() ->
     "keep-alive: timeout=213\r\n"
     "prOxy-Authorization: whatever\r\n"
     "proxy-AuthentiCation: 0\r\n"
+    "\r\n"
+    "abcdefghijklmnoprstuvwxyz1234567890abcdef\r\n".
+
+resp_cookies(Size) ->
+    Val = lists:duplicate(max(1,Size-6), $a),
+    "HTTP/1.1 200 OK\r\n"
+    "Date: Fri, 31 Dec 1999 23:59:59 GMT\r\n"
+    "Content-Type: text/plain\r\n"
+    "Set-Cookie: name="++Val++";\r\n"
+    "Content-Length: 43\r\n"
     "\r\n"
     "abcdefghijklmnoprstuvwxyz1234567890abcdef\r\n".
 


### PR DESCRIPTION
This will keep inadvertently (or purposefully) setting cookie lines
longer than what most proxies (including vegur, by default) will allow
back in a request.
