### PR TITLE
Fix errors on never-checked out services

### DIFF
--- a/src/vegur_midjan_middleware.erl
+++ b/src/vegur_midjan_middleware.erl
@@ -32,8 +32,13 @@ finally(Return) ->
     {InterfaceModule, HandlerState, Req1} = vegur_utils:get_interface_module(Req),
     {DomainGroup, Req2} = cowboy_req:meta(domain_group, Req1),
     {Service, Req3} = cowboy_req:meta(service, Req2),
-    {ok, HandlerState2} = InterfaceModule:checkin_service(DomainGroup, Service, normal, HandlerState),
-    ReqFinal = vegur_utils:set_handler_state(HandlerState2, Req3),
+    ReqFinal = case {DomainGroup, Service} of
+        {undefined, undefined} -> %% Never checked out anything
+            Req3;
+        _ ->
+            {ok, HandlerState2} = InterfaceModule:checkin_service(DomainGroup, Service, normal, HandlerState),
+            vegur_utils:set_handler_state(HandlerState2, Req3)
+    end,
     %% Call the logger
     Final = case Return of
         {halt, _} -> {halt, ReqFinal};


### PR DESCRIPTION
This should fix the errors we keep seeing with:

```
h-2.3023: Error in process <0.12433.10> on node '...' with exit value: {function_clause,[{hermes_route,unlink_service,[undefined,undefined],[{file,"src/h_route.erl"},{line,101}]},{h_interface,checkin_service,4,[{file,"src/h_interface.erl"},{line,141}]},{vegur_midjan_middleware...
```
