### PR TITLE
closing an in-progress chunked conn leaves data on

### DIFF
--- a/src/vegur_client.erl
+++ b/src/vegur_client.erl
@@ -336,7 +336,10 @@ stream_close(Client=#client{buffer=Buffer, response_body=undefined, bytes_recv=B
             end;
         _ ->
             {ok, Buffer, Client#client{buffer = <<>>}}
-    end.
+    end;
+stream_close({Client=#client{}, _Continuation}) ->
+    %% Used as a wrapper for streamed connections
+    stream_close(Client).
 
 skip_body(Client=#client{state=response_body}) ->
     case stream_body(Client) of


### PR DESCRIPTION
The chunked mechanism in vegur makes use of a continuation wrapped along
with the #client{} record to transparently work across packet
boundaries.

However, when the connection is killed, the client along with the
continuation is passed to vegur_client:close/1, which ends up failing
with a function_clause error.

This patch makes it so that close/1 expects the continuation to be there
as part of regular operations to keep the abstraction going and silence
the errors.
