### PR TITLE
Fix status=0 logs

### DIFF
--- a/src/vegur_proxy_middleware.erl
+++ b/src/vegur_proxy_middleware.erl
@@ -62,7 +62,8 @@ read_backend_response(Req, #state{backend_client=BackendClient}=State) ->
     end.
 
 handle_backend_response(Code, RespHeaders, Req, State) ->
-    {Type, Req2} = cowboy_req:meta(request_type, Req, []),
+    Req1 = cowboy_req:set_meta(response_code, Code, Req),
+    {Type, Req2} = cowboy_req:meta(request_type, Req1, []),
     case lists:sort(Type) of
         [] ->
             http_request(Code, RespHeaders, Req2, State);


### PR DESCRIPTION
The status needs to be saved at request time and only overriden if an
error occured in the callback module. Otherwise, trust the one seen in
the proxy itself.
