### PR TITLE
add x-request-start header to reqs

### DIFF
--- a/src/vegur.app.src
+++ b/src/vegur.app.src
@@ -10,6 +10,7 @@
   ,{env, [{acceptors, 1024}
           ,{max_connections, 100000}
           ,{request_id_name, <<"x-request-id">>}
+          ,{start_time_header, <<"x-request-start">>}
           ,{connect_time_header, <<"connect-time">>}
           ,{route_time_header, <<"total-route-time">>}
           ,{instance_name, <<"vegur">>}

--- a/src/vegur_req_log.erl
+++ b/src/vegur_req_log.erl
@@ -74,7 +74,7 @@ stamp(EventType, T, Details, Log = #log{events = Q}) ->
 timestamp_diff(BeginningEventType, EndingEventType, Log) ->
     timestamp_diff(BeginningEventType, EndingEventType, undefined, Log).
 
-%% returns a millisecond diff between two event_types if there exists a 
+%% returns a millisecond diff between two event_types if there exists a
 %% single stamp for each event_type
 -spec timestamp_diff(event_type(), event_type(), term(), request_log()) -> term().
 timestamp_diff(BeginningEventType, EndingEventType, Default, Log) ->

--- a/test/vegur_proxy_SUITE.erl
+++ b/test/vegur_proxy_SUITE.erl
@@ -17,6 +17,7 @@ groups() ->
                                 ,forwarded_for
                                 ,via
                                 ,connect_time_header
+                                ,start_time_header
                                 ,route_time_header
                                 ,host
                                 ,query_string
@@ -182,6 +183,19 @@ via(Config) ->
     end,
     Config.
 
+start_time_header(Config) ->
+    Port = ?config(vegur_port, Config),
+    Url = "http://127.0.0.1:" ++ integer_to_list(Port),
+    {ok, {{_, 204, _}, _, _}} = httpc:request(get, {Url, [{"host", "localhost"}]}, [], []),
+    receive
+        {req, Req} ->
+            {Res, _} = cowboy_req:header(vegur_utils:config(start_time_header), Req),
+            true = is_integer(list_to_integer(binary_to_list(Res)))
+    after 5000 ->
+            throw(timeout)
+    end,
+    Config.
+
 connect_time_header(Config) ->
     Port = ?config(vegur_port, Config),
     Url = "http://127.0.0.1:" ++ integer_to_list(Port),
@@ -236,7 +250,7 @@ request_statistics(Config) ->
             receive
                 {stats, {successful, Upstream, _State}} ->
                     {118, _} = vegur_req:bytes_recv(Upstream),
-                    {250, _} = vegur_req:bytes_sent(Upstream),
+                    {282, _} = vegur_req:bytes_sent(Upstream),
                     {RT, _} = vegur_req:route_duration(Upstream),
                     {CT, _} = vegur_req:connect_duration(Upstream),
                     {TT, _} = vegur_req:total_duration(Upstream),


### PR DESCRIPTION
X-Reqest-Start is the name of the header used to know the time a request first entered the proxy handler. This is particularly needed by the canaries for calculating time from checker to router.
