### PR TITLE
Detect upstream closing of connections

### DIFF
--- a/src/vegur_stub.erl
+++ b/src/vegur_stub.erl
@@ -146,9 +146,6 @@ error_page({downstream, status_length}, _DomainGroup, Upstream, HandlerState) ->
 error_page({upstream, {bad_chunk,_}}, _DomainGroup, Upstream, HandlerState) ->
     %% bad chunked encoding from client
     {{400, [], <<>>}, Upstream, HandlerState};
-error_page({upstream, unexpected_data_full_buffer}, _DomainGroup, Upstream, HandlerState) ->
-    %% pipelined request (maybe), not supported.
-    {{400, [], <<>>}, Upstream, HandlerState};
 error_page({downstream, {bad_chunk,_}}, _DomainGroup, Upstream, HandlerState) ->
     %% bad chunked encoding from server
     {{502, [], <<>>}, Upstream, HandlerState};


### PR DESCRIPTION
Whenever the socket is closed, see that it is noticed as such by
vegur_proxy when relaying data from the backend to the front-end.
