### PR TITLE
Add test for chunks and errors

### DIFF
--- a/test/vegur_roundtrip_SUITE.erl
+++ b/test/vegur_roundtrip_SUITE.erl
@@ -26,7 +26,8 @@ groups() -> [{continue, [], [
                 chunked_to_1_0
              ]},
              {chunked, [], [
-                passthrough, interrupted_client, interrupted_server
+                passthrough, interrupted_client, interrupted_server,
+                bad_chunk
              ]},
              {body_less, [], [
                 head_small_body_expect, head_large_body_expect,
@@ -921,6 +922,33 @@ interrupted_server(Config) ->
     ct:pal("RecvClient: ~p",[RecvClient]),
     check_stub_error({downstream, closed}).
 
+bad_chunk(Config) ->
+    %% Chunked data can move through the stack without being modified.
+    %% We *could* re-chunk data, but leaving chunks as is is more
+    %% transparent and also easier.
+    IP = ?config(server_ip, Config),
+    Port = ?config(proxy_port, Config),
+    Chunks = "3\r\nabc\r\n5\r\ndefgh\r\ne\r\nijklmnopqrstuv\r\n0\r\n\r\n",
+    BadChunks = "3\r\nabc\r\n5\r\ndefgh\r\ne\r\nijklmnopqrstuvkjalnfksl\r\n0\r\n\r\n",
+    Req = [chunked_headers(Config), Chunks],
+    Resp = [resp_headers(chunked), BadChunks],
+    %% Open the server to listening. We then need to send data for the
+    %% proxy to get the request and contact a back-end
+    Ref = make_ref(),
+    start_acceptor(Ref, Config),
+    {ok, Client} = gen_tcp:connect(IP, Port, [{active,false},list],1000),
+    ok = gen_tcp:send(Client, Req),
+    %% Fetch the server socket
+    Server = get_accepted(Ref),
+    %% Exchange all the data
+    RecvServ = recv_until_timeout(Server),
+    ok = gen_tcp:send(Server, Resp),
+    RecvClient = recv_until_close(Client),
+    %% Check final connection status
+    ct:pal("RecvServ: ~p~nRecvClient: ~p",[RecvServ,RecvClient]),
+    {match, _} = re:run(RecvClient, "200"),
+    nomatch = re:run(RecvClient, "502"), % can't report an error halfway through
+    wait_for_closed(Server, 500).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% BODY LESS REQUEST BEHAVIOUR %%%


### PR DESCRIPTION
Make sure that error pages aren't reported halfway through a chunked
stream.

After verification, I have seen no case where this should happen.

[A function](https://github.com/heroku/cowboy/blob/heroku_proxy/src/cowboy_req.erl#L1152) is called whenever an error happens to know if there _should_ be an error page added (see https://github.com/heroku/cowboy/blob/heroku_proxy/src/cowboy_protocol.erl#L592), but it turns out that because we use the cowboy mechanisms for all protocols (chunked replies, streamed replies, content-length replies, 100-continued replies that send headers) except websockets, the error page seems to always be avoided through calls to [cowboy_req:response](https://github.com/heroku/cowboy/blob/heroku_proxy/src/cowboy_req.erl#L1345-1361), (which is called through reply/2 also).

Websockets aren't a problem because we close the connection every time.

I'm still adding the test case because it's there, let me know if you think we should add more cases for other types of transfers.
