### PR TITLE
Support custom HTTP codes and statuses

### DIFF
--- a/src/vegur_client.erl
+++ b/src/vegur_client.erl
@@ -218,10 +218,14 @@ response(Client=#client{state=response_body}) ->
     response(set_stats(Client2));
 response(Client=#client{state=request}) ->
     case stream_status(Client) of
-        {ok, Status, _, Client2} ->
+        {ok, Status, StatusStr, Client2} ->
             case stream_headers(Client2) of
                 {ok, Headers, Client3} ->
-                    {ok, Status, Headers, set_stats(Client3)};
+                    {ok,
+                     Status,
+                     <<(integer_to_binary(Status))/binary, " ", StatusStr/binary>>,
+                     Headers,
+                     set_stats(Client3)};
                 {error, Reason} ->
                     {error, Reason}
             end;

--- a/src/vegur_req_log.erl
+++ b/src/vegur_req_log.erl
@@ -178,7 +178,7 @@ event_duration(Name, #log{events=Events}) ->
     end.
 
 -spec event(Name, Log) ->
-                   ms()|undefined when
+        erlang:timestamp()|undefined when
       Name :: event_type(),
       Log :: request_log().
 event(Name, Log) ->


### PR DESCRIPTION
- The HTTP code still needs to be 3-digits long as per RFC
- The Status length is still restricted to standard stuff
- Custom status lines should be passed as-is
- Includes tests

This also sees a general renaming from `Status` to `Code` when `Status`
would contain an integer -- `Code` now refers to 100...999 integers, and
`Status` to binaries representing the HTTP values such as `<<"404 NOT
FOUND">>`
