### PR TITLE
Make client request errors more specific

### DIFF
--- a/src/vegur_continue_middleware.erl
+++ b/src/vegur_continue_middleware.erl
@@ -18,7 +18,7 @@ execute(Req, Env) ->
             {error, HttpCode, Req1};
         {error, _} ->
             %% Bad request, invalid header value
-            {HttpCode, Req1} = vegur_utils:handle_error(bad_request, Req),
+            {HttpCode, Req1} = vegur_utils:handle_error(bad_request_header, Req),
             {error, HttpCode, Req1}
     end.
 

--- a/src/vegur_stub.erl
+++ b/src/vegur_stub.erl
@@ -179,6 +179,8 @@ error_page(empty_host, _DomainGroup, Upstream, HandlerState) ->
     {{400, [], <<>>}, Upstream, HandlerState};
 error_page(bad_request, _DomainGroup, Upstream, HandlerState) ->
     {{400, [], <<>>}, Upstream, HandlerState};
+error_page(bad_request_header, _DomainGroup, Upstream, HandlerState) ->
+    {{400, [], <<>>}, Upstream, HandlerState};
 error_page(_, _DomainGroup, Upstream, HandlerState) ->
     {{503, [], <<>>}, Upstream, HandlerState}.
 

--- a/src/vegur_upgrade_middleware.erl
+++ b/src/vegur_upgrade_middleware.erl
@@ -14,20 +14,20 @@ match_headers({ok,{ConnectionTokens, Req1}}, _, Env) ->
             %% The connection should be upgraded
             case cowboy_req:parse_header(<<"upgrade">>, Req1) of
                 {ok, undefined, Req2} ->
-                    {HttpCode, Req3} = vegur_utils:handle_error(bad_request, Req2),
+                    {HttpCode, Req3} = vegur_utils:handle_error(bad_request_header, Req2),
                     {error, HttpCode, Req3};
                 {ok, Upgrade, Req2} ->
                     handle_upgrade(Upgrade, Req2, Env);
                 {undefined, _, Req2} ->
-                    {HttpCode, Req3} = vegur_utils:handle_error(bad_request, Req2),
+                    {HttpCode, Req3} = vegur_utils:handle_error(bad_request_header, Req2),
                     {error, HttpCode, Req3}; % 426?
                 _ ->
-                    {HttpCode, Req2} = vegur_utils:handle_error(bad_request, Req1),
+                    {HttpCode, Req2} = vegur_utils:handle_error(bad_request_header, Req1),
                     {error, HttpCode, Req2}
             end
     end;
 match_headers({error,_}, Req, _Env) ->
-    {HttpCode, Req1} = vegur_utils:handle_error(bad_request, Req),
+    {HttpCode, Req1} = vegur_utils:handle_error(bad_request_header, Req),
     {error, HttpCode, Req1}.
 
 % http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.42


### PR DESCRIPTION
This leaves 'bad_request' available (although unused for now), while
adding specifics regarding errors that are due to bad request headers.
This will allow callback modules to get more accurate reporting out of
things.
