### PR TITLE
Force strict parsing of chunked content

### DIFF
--- a/src/vegur_chunked.erl
+++ b/src/vegur_chunked.erl
@@ -99,8 +99,8 @@ chunk_size(<<"\r\n", Rest/binary>>, S=#state{length=Len, buffer=Buf}) ->
             case Rest of
                 <<"\r\n", Remainder/binary>> -> % body-ending CLRF
                     {done, [Buf, <<"\r\n\r\n">>], Remainder};
-                _ -> % we tolerate that
-                    {done, [Buf, <<"\r\n">>], Rest}
+                _ -> % 0-length chunk
+                    {chunk, [Buf, <<"\r\n">>], Rest}
             end;
         undefined ->
             {error, {bad_chunk, no_length}};

--- a/src/vegur_unchunked.erl
+++ b/src/vegur_unchunked.erl
@@ -95,8 +95,8 @@ chunk_size(<<"\r\n", Rest/binary>>, S=#state{length=Len, buffer=Buf}) ->
             case Rest of
                 <<"\r\n", Remainder/binary>> -> % body-ending CLRF
                     {done, Buf, Remainder};
-                _ -> % we tolerate that
-                    {done, Buf, Rest}
+                _ -> % 0-length chunk, skip-ahead
+                    chunk_size(Rest, S#state{length=undefined, buffer=[]})
             end;
         undefined ->
             {error, {bad_chunk, no_length}};

--- a/test/vegur_chunked_SUITE.erl
+++ b/test/vegur_chunked_SUITE.erl
@@ -43,7 +43,6 @@ short_msg(_) ->
     {more, Rest3} = vegur_chunked:next_chunk(<<"d en">>, Rest2),
     {chunk, _, <<"">>} = vegur_chunked:next_chunk(<<"coded\r\n">>, Rest3),
     {more, Rest4} = vegur_chunked:next_chunk(<<"00">>),
-    {done, _, <<"">>} = vegur_chunked:next_chunk(<<"\r\n">>, Rest4),
     {done, _, <<"">>} = vegur_chunked:next_chunk(<<"\r\n\r\n">>, Rest4).
 
 html(_) ->
@@ -52,11 +51,12 @@ html(_) ->
     "<h1>go!</h1>\r\n"
     "1b\r\n"
     "<h1>first chunk loaded</h1>\r\n"
+    "0\r\n" % 0-length chunk
     "2a\r\n"
     "<h1>second chunk loaded and displayed</h1>\r\n"
     "29\r\n"
     "<h1>third chunk loaded and displayed</h1>\r\n"
-    "0\r\n">>,
+    "0\r\n\r\n">>,
     {done, Buf, <<>>} = vegur_chunked:all_chunks(String),
     String = iolist_to_binary(Buf).
 
@@ -74,7 +74,7 @@ stream(_) ->
     Str5 = <<" loaded and displayed</h1>\r\n"
     "29\r\n"
     "<h1>third chunk loaded and displayed</h1>\r\n"
-    "0\r\n">>,
+    "0\r\n\r\n">>,
     %% remaining length is 12 given we haven't started parsing the message below
     {more, 12, Buf1, Cont1} = vegur_chunked:stream_chunk(Str1),
     {chunk, Buf2, Rest1} = vegur_chunked:stream_chunk(Str2, Cont1),
@@ -102,7 +102,7 @@ trailers(_) ->
     "Sat, 20 Mar 2004 21:12:00 GMT\r\n"
     "13\r\n"
     ".</p></body></html>\r\n"
-    "0\r\n"
+    "0\r\n\r\n"
     "Expires: Sat, 27 Mar 2004 21:12:00 GMT\r\n">>,
     {done, Buf, <<>>} = vegur_chunked:all_chunks(String, <<"Expires">>),
     String = iolist_to_binary(Buf).

--- a/test/vegur_unchunked_SUITE.erl
+++ b/test/vegur_unchunked_SUITE.erl
@@ -41,7 +41,6 @@ short_msg(_) ->
     {more, Rest3} = vegur_unchunked:next_chunk(<<"d en">>, Rest2),
     {chunk, _, <<"">>} = vegur_unchunked:next_chunk(<<"coded\r\n">>, Rest3),
     {more, Rest4} = vegur_unchunked:next_chunk(<<"00">>),
-    {done, _, <<"">>} = vegur_unchunked:next_chunk(<<"\r\n">>, Rest4),
     {done, _, <<"">>} = vegur_unchunked:next_chunk(<<"\r\n\r\n">>, Rest4).
 
 html(_) ->
@@ -50,11 +49,12 @@ html(_) ->
     "<h1>go!</h1>\r\n"
     "1b\r\n"
     "<h1>first chunk loaded</h1>\r\n"
+    "0\r\n" % 0-length chunk
     "2a\r\n"
     "<h1>second chunk loaded and displayed</h1>\r\n"
     "29\r\n"
     "<h1>third chunk loaded and displayed</h1>\r\n"
-    "0\r\n">>,
+    "0\r\n\r\n">>,
     {done, Buf, <<>>} = vegur_unchunked:all_chunks(String),
     <<"<h1>go!</h1>"
       "<h1>first chunk loaded</h1>"
@@ -75,7 +75,7 @@ stream(_) ->
     Str5 = <<" loaded and displayed</h1>\r\n"
     "29\r\n"
     "<h1>third chunk loaded and displayed</h1>\r\n"
-    "0\r\n">>,
+    "0\r\n\r\n">>,
     %% remaining length is 12 given we haven't started parsing the message below
     {more, 12, Buf1, Cont1} = vegur_unchunked:stream_chunk(Str1),
     {chunk, Buf2, Rest1} = vegur_unchunked:stream_chunk(Str2, Cont1),


### PR DESCRIPTION
The parser no longer allows a chunked stream to end without a full
'0\r\n\r\n', to allow the usage of 0-length chunks (0\r\n) without
interrupting a stream halfway through.
