### PR TITLE
Eliminate disconnection errors on skip body

### DIFF
--- a/src/vegur_client.erl
+++ b/src/vegur_client.erl
@@ -214,8 +214,12 @@ parse_peer(Peer, Transport) ->
     end.
 
 response(Client=#client{state=response_body}) ->
-    {done, Client2} = skip_body(Client),
-    response(set_stats(Client2));
+    case skip_body(Client) of
+        {done, Client2} ->
+            response(set_stats(Client2));
+        {error, Reason} ->
+            {error, Reason}
+    end;
 response(Client=#client{state=request}) ->
     case stream_status(Client) of
         {ok, Status, StatusStr, Client2} ->


### PR DESCRIPTION
When the client to a back-end needs to skip the body and the connection
is interrupted halfway through, avoid crashing and return the error
instead.

Eliminates errors such as

```
Error in process <0.7255.907> on node 'name@ip-127-0-0-1.ec2.internal' with exit value: {{badmatch,
{error,closed}},[{vegur_client,response,1,[{file,"src/vegur_client.erl"},{line,217}]},{vegur_proxy,read_response,1,
[{file,"src/vegur_proxy.erl"},{line,145}]},{vegur_proxy,read_backend_response,2,[{file,"src/vegur...
```
