### PR TITLE
add required, by systools, registered key to app file

### DIFF
--- a/src/vegur.app.src
+++ b/src/vegur.app.src
@@ -2,6 +2,7 @@
  [
    {description, "vegur"}
   ,{vsn, "0.14.0"}
+  ,{registered, []}
   ,{applications,
     [kernel
      ,stdlib


### PR DESCRIPTION
http://www.erlang.org/doc/man/app.html

The functions in systools require more information. If they are used, the following keys are mandatory: description, vsn, modules, registered and applications. The other keys are ignored by systools.

All names of registered processes started in this application. systools uses this list to detect name clashes between different applications.
