### PR TITLE
Relax reason phrase parsing

### DIFF
--- a/src/vegur_client.erl
+++ b/src/vegur_client.erl
@@ -68,7 +68,7 @@
 -export([byte_counts/1]).
 -export([log/1]).
 
--define(REASON_MISSING, <<"Unknown">>). %% "EBADDEVELOPER"
+-define(REASON_MISSING, <<"">>). %% "EBADDEVELOPER"
 
 -record(client, {
           state = wait :: wait | request | response | response_body | raw,

--- a/test/vegur_client_SUITE.erl
+++ b/test/vegur_client_SUITE.erl
@@ -80,7 +80,7 @@ missing_reason_phrase_resp(Socket, Transport) ->
 
 missing_reason_phrase(Config) ->
     dyno_req(?config(dyno_port, Config),
-             421, <<"421 Unknown">>).
+             421, <<"421 ">>).
 
 deliberate_reason_phrase_resp(Socket, Transport) ->
     Transport:send(Socket,


### PR DESCRIPTION
Allows origin servers to omit the reason phrase in their HTTP responses.

Adds a tiny test suite for vegur_client.
