### PR TITLE
Test for HTTP 1.0 host-free proper routing

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,7 @@
    {git, "git@github.com:heroku/ranch.git", {branch, "heroku_client"}}}
  ,{cowlib, ".*", {git, "git://github.com/extend/cowlib.git", {tag, "0.4.0"}}}
  ,{cowboy, "",
-  %{git, "git@github.com:heroku/cowboy.git", {branch, "heroku_proxy"}}}
-   {git, "git@github.com:heroku/cowboy.git", {branch, "heroku_proxy_1_0_nohost"}}}
+   {git, "git@github.com:heroku/cowboy.git", {branch, "heroku_proxy"}}}
  ,{ranch_proxy_protocol, "",
    {git, "git@github.com:heroku/ranch_proxy_protocol.git", {tag, "1.0.0"}}}
  ,{uuid, "",


### PR DESCRIPTION
Depends on https://github.com/heroku/cowboy/pull/10 being merged first.

HTTP ELBs do it, and the HTTP/1.0 Spec requires it.

It's a shame but that's how it is.
