### PR TITLE
Allow different connect timeout

### DIFF
--- a/src/vegur_interface.erl
+++ b/src/vegur_interface.erl
@@ -15,6 +15,7 @@
                 {route_time|connect_time|total_time, ms()}.
 -type stats() :: [stat()]|[].
 -type feature() :: deep_continue | peer_port.
+-type connect_options() :: [{connect_timeout, non_neg_integer()}].
 -opaque upstream() :: cowboy_req:req().
 
 -export_type([domain/0,
@@ -31,7 +32,8 @@
               stats/0,
               ms/0,
               feature/0,
-              upstream/0]).
+              upstream/0,
+              connect_options/0]).
 
 -callback init(RequestAccepted, Upstream) ->
     {ok, Upstream, HandlerState} when
@@ -85,7 +87,7 @@
     {ServiceBackend, ConnectOpts, Upstream, HandlerState} when
       Service :: service(),
       ServiceBackend :: service_backend(),
-      ConnectOpts :: [term()],
+      ConnectOpts :: connect_options(),
       Upstream :: upstream(),
       HandlerState :: handler_state().
 

--- a/src/vegur_lookup_service_middleware.erl
+++ b/src/vegur_lookup_service_middleware.erl
@@ -63,7 +63,7 @@ handle_error(Reason, Req, _Env) ->
       InterfaceModule :: module(),
       Service :: vegur_interface:service(),
       ServiceBackend :: vegur_interface:service_backend(),
-      ConnectOpts :: [term()],
+      ConnectOpts :: vegur_interface:connect_options(),
       Upstream :: vegur_interface:upstream(),
       HandlerState :: vegur_interface:handler_state(),
       Req :: cowboy_req:req().

--- a/src/vegur_proxy.erl
+++ b/src/vegur_proxy.erl
@@ -22,6 +22,12 @@
 backend_connection(ServiceBackend) ->
     backend_connection(ServiceBackend, []).
 
+-spec backend_connection(ServiceBackend, ConnectOptions) ->
+                                {connected, Client} |
+                                {error, any()} when
+      ServiceBackend :: vegur_interface:service_backend(),
+      ConnectOptions :: vegur_interface:connect_options(),
+      Client :: vegur_client:client().
 backend_connection({IpAddress, Port}, Opts) ->
     ConnectTimeout = proplists:get_value(connect_timeout, Opts,
                                          vegur_utils:config(downstream_connect_timeout)),


### PR DESCRIPTION
A part of using different routing logic is being able to control how long the connect timeout should be. It would allow us do more retries etc.
