### PR TITLE
Add docs for configuration, remove unused defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,56 @@ And how do you pronounce vegur? Like [this](https://soundcloud.com/omarkj/vegur)
 
     $ rebar ct
 
+## Writing a Router
+
+Vegur is a *proxy* application, meaning that it takes care of receiving HTTP requests and
+forwarding them to another server; similarly for responses.
+
+What it isn't is a *router*, meaning that it will not handle choosing which nodes to send
+traffic to, nor will it actually track what backends are available. This task is left to
+the user of the library, by writing a router callback module.
+
+The documentation for this isn't complete yet. In the mean time, feel free to reverse-engineer
+what has been done in `src/vegur_stub.erl`, which provides an example implementation.
+
+## Behaviour
+
+There are multiple specific HTTP behaviours that have been chosen/implemented in this proxying
+software. The list is maintained at https://devcenter.heroku.com/articles/heroku-improved-router
+
+## Configuration
+
+### OTP Configuration
+
+The configuration can be passed following the standard Erlang/OTP application logic.
+
+- `{acceptors, pos_integer()}`: number of HTTP acceptors expected. Defaults to `1024`.
+- `{max_connections, pos_integer()}`: max number of active HTTP connections (inbound). Defaults to `100000`.
+- `{request_id_name, binary()}`: Vegur will read a request id header and pass it on to the proxied request. It will also automatically insert a header with a request id if none is present. This item configures the name of such an ID, and defaults to `X-Request-Id`.
+- `{request_id_max_size, pos_integer()}`: The request Id submitted can be forced to have a maximal size, after which it is considered invalid and a new one is generated. Defaults to `200`.
+- `{start_time_header, binary()}`: Vegur will insert a header representing the epoch at which the request started based on the current node's clock. This allows to specify the name of that header. Defaults to `X-Request-Start`.
+- `{connect_time_header, binary()}`: A header is added noting the time it took to establish a connection to the back-end node provided. This allows to set the name of this header. Defaults to `Connect-Time`.
+- `{route_time_header, binary()}`: A header is added noting the time it took the routing callback module to make its decision. This allows to set the name of this header. Defaults to `Total-Route-Time`.
+- `{idle_timeout, non_neg_integer()}`: Maximal period of inactivity during a session, in seconds. Defaults to 55.
+- `{downstream_connect_timeout, timeout()}`: Maximal time period to wait before abandoning the connection to a backend, in milliseconds. Defaults to 5000ms.
+- `{downstream_timeout, non_neg_integer()}`: Maximal time period to wait before abandonning the wait for a response after a request has been forwarded to a back-end, in seconds. Defaults to 30. This value is purely for the initial response, after which `idle_timeout` takes over as a value.
+- `{client_tcp_buffer_limit, pos_integer()}`: Size of the TCP buffer for the socket to the backend server, in bytes. Defaults to `1048576` (`1024*1024` bytes).
+- `{max_client_status_length, pos_integer()}`: Maximal size of the status line of the client response, in bytes. Defaults to `8192`.
+- `{max_client_header_length, pos_integer()}`: Maximal size of a given response header line, in bytes. Defaults to `524288`, or 512kb.
+- `{max_client_cookie_length, pos_integer()}`: Maximal size of a cookie in a response, in bytes. Defaults to `8192`.
+
+### Server Configuration
+
+The HTTP servers themselves can also have their own configuration in a per-listener manner. The following options are valid when passed to `vegur:start/5`:
+
+- `{max_request_line_length, pos_integer()}`: Maximal line size for the HTTP request. Defaults to 8192. Note that this value may be disregarded if the entire line managed to fit within the confines of a single HTTP packet or `recv` operation.
+- `{max_header_name_length, pos_integer()}`: Maximal length for header names in HTTP requests. Defaults to `1000`. Note that this value may be disregarded if the entire line managed to fit within the confines of a single HTTP packet or `recv` operation.
+- `{max_header_value_length, pos_integer()}`: Maximal length for the value of a header in HTTP requests. Defaults to `8192`. Note that this value may be disregarded if the entire line managed to fit within the confines of a single HTTP packet or `recv` operation.
+- `{max__headers, pos_integer()}`: number of HTTP headers allowed in a single request. Defaults to 1000.
+- `{timeout, timeout()}`: Delay, in milliseconds, after which a connection is closed for inactivity. This delay also specifies the maximal time that an idle connection being pre-opened by some service for efficiency reasons will remain open without receiving a request on it.
+
+It is recommended that options regarding header sizes for the HTTP listener match the options for the `max_cookie_length` in the OTP options to avoid the painful case of a backend setting a cookie that cannot be sent back by the end client.
+
 Logs and statistics being collected
 -----------------------------------
 

--- a/src/vegur.app.src
+++ b/src/vegur.app.src
@@ -18,7 +18,6 @@
           ,{start_time_header, <<"x-request-start">>}
           ,{connect_time_header, <<"connect-time">>}
           ,{route_time_header, <<"total-route-time">>}
-          ,{instance_name, <<"vegur">>}
           ,{request_id_max_size, 200}
           ,{idle_timeout, 55} % seconds
           ,{downstream_connect_timeout, 5000} % milliseconds

--- a/src/vegur.erl
+++ b/src/vegur.erl
@@ -161,8 +161,4 @@ defaults() ->
      ,{timeout, timer:seconds(60)}
      ,{onrequest, fun vegur_request_log:new/1}
      ,{onresponse, fun vegur_request_log:done/4}
-     ,{request_id_name, <<"x-request-id">>}
-     ,{connect_time_header, <<"connect-time">>}
-     ,{route_time_header, <<"total-route-time">>}
-     ,{request_id_max_size, 200}
     ].

--- a/src/vegur_client.erl
+++ b/src/vegur_client.erl
@@ -80,7 +80,7 @@
           buffer = <<>> :: binary(),
           connection = keepalive :: keepalive | close,
           version = 'HTTP/1.1' :: cowboy:http_version(),
-          status = undefined :: 100..999,
+          status = undefined :: 100..999 | undefined, % can be undefined before parsing
           response_body = undefined :: chunked | undefined | non_neg_integer(),
           bytes_sent :: non_neg_integer() | undefined, % Bytes sent downstream
           bytes_recv :: non_neg_integer() | undefined, % Bytes recv from downstream

--- a/src/vegur_stub.erl
+++ b/src/vegur_stub.erl
@@ -15,7 +15,7 @@
 
 -record(state, {
            connect_tries = 0 :: non_neg_integer()
-	      ,features = [] :: [atom()]
+          ,features = [] :: [atom()]
          }).
 
 
@@ -82,7 +82,7 @@ feature(_, State) ->
       HandlerState :: vegur_interface:handler_state().
 additional_headers(Log, HandlerState=#state{features=Features}) ->
     case lists:member(router_metrics, Features) of
-		true ->
+        true ->
             ConnectDuration = vegur_req_log:connect_duration(Log),
             StartToProxy = vegur_req_log:start_to_proxy_duration(Log),
             Headers = [{<<"Heroku-Hermes-Instance-Name">>, instance_name()}


### PR DESCRIPTION
Documenting config options found out that a bunch of options were
(apparently) superficial and unneeded. No tests broke.
