### PR TITLE
Remove trailing errors on interrupting errors

### DIFF
--- a/src/vegur_continue_middleware.erl
+++ b/src/vegur_continue_middleware.erl
@@ -33,7 +33,7 @@ handle_feature(Req, Env) ->
             Headers = cowboy_req:get(headers, Req3),
             NewHeaders = vegur_utils:delete_all_headers(<<"expect">>, Headers),
             Req4 = cowboy_req:set([{headers, NewHeaders}], Req3),
-            {{Transport, Socket}, _Discard} = vegur_utils:raw_cowboy_socket(Req4),
+            {Transport, Socket} = vegur_utils:borrow_cowboy_socket(Req4),
             Transport:send(Socket, <<"HTTP/1.1 100 Continue\r\n\r\n">>),
             {Req4, Env}
     end.

--- a/src/vegur_proxy.erl
+++ b/src/vegur_proxy.erl
@@ -201,7 +201,7 @@ read_backend_response(Req, Client) ->
 
 send_continue(Req, BackendClient) ->
     HTTPVer = atom_to_binary(vegur_client:version(BackendClient), latin1),
-    {{Transport,Socket}, _} = vegur_utils:raw_cowboy_socket(Req),
+    {Transport,Socket} = vegur_utils:borrow_cowboy_socket(Req),
     Transport:send(Socket,
         [HTTPVer, <<" 100 Continue\r\n\r\n">>]),
     %% Got it. Now clean up the '100 Continue' state from

--- a/test/vegur_roundtrip_SUITE.erl
+++ b/test/vegur_roundtrip_SUITE.erl
@@ -1046,8 +1046,9 @@ passthrough_early_0length(Config) ->
     %% The good request
     {match,_} = re:run(RecvClient, "200 OK"),
     {match,_} = re:run(RecvClient, "3\r\nabc\r\n0\r\n"),
-    %% Garbage left on the line
-    {match,_} = re:run(RecvClient, "400 Bad Request"),
+    %% Garbage left on the line doesn't exist anymore (it used to) as
+    %% the connection gets closed.
+    nomatch = re:run(RecvClient, "400 Bad Request"),
     wait_for_closed(Server, 500).
 
 interrupted_client(Config) ->
@@ -1277,8 +1278,9 @@ trailers_skip(Config) ->
     nomatch = re:run(RecvServ, "head: ?val", [global, multiline, caseless]),
     nomatch = re:run(RecvClient, "head: ?val", [global, multiline, caseless]),
     {match,_} = re:run(RecvClient, "^HTTP/1.1 200 OK", [global,multiline,caseless]),
-    %% The garbage from the client is seen as a bad request
-    {match,_} = re:run(RecvClient, "0\r\nHTTP/1.1 400", [global,multiline,caseless]),
+    %% The garbage from the client is ignored and the connection is closed
+    %% before then
+    nomatch = re:run(RecvClient, "0\r\nHTTP/1.1 400", [global,multiline,caseless]),
     wait_for_closed(Server, 500).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This change introduces the function `borrow_cowboy_socket/1`, a
varition of `raw_cowboy_socket/1`, which has been fixed for edge
behaviours.

The `raw_cowboy_socket/1` function was intended for the proxy taking
over cowboy when it came to requests. For this reason, it tried to mark
the request as closed, but had forgotten to send the internal cowboy
message used to deal through abnormal exception flow -- this is fixed
both there and in `raw_cowboy_sockbuf/1`.

In the case of `100 Continue` responses, the intended use was to add
data to the connection, but without actually taking over the connection
permanently. Marking it as closed could cause issues, and for this
reason, the value was ignored.

However, when fixing the behaviour of `raw_cowboy_socket/1`, the marking
of the connection became impure, yielding early termination in such
responses. The `borrow_cowboy_socket/1` function is added to represent
the original intended use from the existing one.

Tests have been altered to reflect this change.
