### PR TITLE
Fix large uploads interrupted by eager response

### DIFF
--- a/src/vegur_client.erl
+++ b/src/vegur_client.erl
@@ -54,6 +54,7 @@
 -export([stream_chunk/1]).
 -export([stream_unchunk/1]).
 -export([buffer_data/3]).
+-export([append_to_buffer/2]).
 
 -export([body_type/1]).
 -export([version/1]).
@@ -62,6 +63,7 @@
 -export([request_to_headers_iolist/6]).
 -export([request_to_iolist/6]).
 -export([raw_socket/1]).
+-export([borrow_socket/1]).
 -export([auth_header/1]).
 
 -export([set_stats/1]).
@@ -203,6 +205,9 @@ request_to_iolist(Method, Headers, Body, Version, FullHost, Path) ->
 
 raw_socket(Client=#client{transport=T, socket=S, buffer=Buf}) ->
     {{T,S}, Buf, Client#client{buffer= <<>>, state=raw}}.
+
+borrow_socket(#client{transport=T, socket=S}) ->
+    {T,S}.
 
 parse_url(<< "https://", Rest/binary >>) ->
     parse_url(Rest, ranch_ssl);
@@ -620,6 +625,9 @@ buffer_data(Length, Timeout, Client=#client{socket=Socket, transport=Transport,
         _ ->
             {ok, Client}
     end.
+
+append_to_buffer(Data, Client=#client{buffer = Buffer}) ->
+    Client#client{buffer = <<Buffer/binary, Data/binary>>}.
 
 header_list_values(Value) ->
     cowboy_http:nonempty_list(Value, fun cowboy_http:token_ci/2).

--- a/src/vegur_utils.erl
+++ b/src/vegur_utils.erl
@@ -19,6 +19,7 @@
          ,raw_cowboy_socket/1
          ,raw_cowboy_sockbuf/1
          ,append_to_cowboy_buffer/2
+         ,mark_cowboy_close/1
         ]).
 
 -export([config/1
@@ -229,6 +230,12 @@ raw_cowboy_sockbuf(Req) ->
 append_to_cowboy_buffer(Buffer, Req) ->
     [CowBuffer] = cowboy_req:get([buffer], Req),
     cowboy_req:set([{buffer, iolist_to_binary([CowBuffer, Buffer])}], Req).
+
+%% Manually force a cowboy request to be closed once the response is done
+-spec mark_cowboy_close(Req) -> Req when
+    Req :: cowboy_req:req().
+mark_cowboy_close(Req) ->
+    cowboy_req:set([{connection,close}], Req).
 
 -spec mark_as_done(Req) -> Req when Req :: cowboy_req:req().
 mark_as_done(Req) ->


### PR DESCRIPTION
When a response comes faster than a large body is being uploaded, with the
backend server then closing its connection rapidly (as is the case with
say, a 403 response to a file upload), vegur may detect the connection
termination as an error and ignore the response on the wire.

This fix adds a 64kb buffer for an early response that will allow vegur
to recognize and accumulate an early response.

In ranch transports where data on the line remeains readable for as long
as possible, this will allow Vegur to push the response as usual after
figuring out it was all a big misunderstanding.

In ranch transports where the connection being closed may shut down the
ability to read the data queued up, this fix will allow to tolerate up
to 64kb of data without a problem.

Given interrupting responses are often error codes (401, 403, 404),
redirections (3xx), or server errors (5xx), and that these tend to have
a limited content, this should cover most cases without much of a
problem.

The buffer size can be made bigger if this is still an issue.

Note that this fix does _not_ speed up the time it may take for the
underlying implementation to figure out a connection has been closed --
this may still take a while. It just makes it so the least amount of
data possible gets lost in the communication.
