### PR TITLE
Be strict on the termination of chunks

### DIFF
--- a/src/vegur_chunked.erl
+++ b/src/vegur_chunked.erl
@@ -34,7 +34,6 @@
          all_chunks/1, all_chunks/2, all_unchunks/1]).
 -record(state, {buffer = <<>> :: binary(),
                 length :: non_neg_integer()|undefined,
-                trailers = undefined,
                 type = chunked :: chunked|unchunked}).
 
 %% Parses a binary stream to get the next chunk in it.
@@ -48,8 +47,6 @@ next_chunk(Bin) -> next_chunk(Bin, undefined).
 
 next_chunk(Bin, undefined) ->
     chunk_size(Bin, #state{type=chunked});
-next_chunk(Bin, trailers) ->
-    chunk_size(Bin, #state{type=chunked, trailers=true});
 next_chunk(Bin, {Fun,State=#state{}}) ->
     Fun(Bin, State).
 
@@ -70,8 +67,6 @@ stream_chunk(Bin) -> stream_chunk(Bin, undefined).
 
 stream_chunk(Bin, undefined) ->
     stream_chunk(Bin, {fun chunk_size/2, #state{type=chunked}});
-stream_chunk(Bin, trailers) ->
-    stream_chunk(Bin, {fun chunk_size/2, #state{type=chunked, trailers=true}});
 stream_chunk(Bin, {Fun, State=#state{}}) ->
     case Fun(Bin, State) of
         {done, Buf, Rest} -> {done, Buf, Rest};
@@ -98,8 +93,6 @@ all_chunks(Bin, F, Acc) ->
     catch
         error:function_clause -> {error, Acc, {bad_chunk, Bin}}
     end.
-
-% next_chunk(Bin, Trailers) -> chunk_size(Bin, #state{trailers=Trailers}).
 
 %%           ,-----------------v
 %% chunk_size -> extension -> data -> last chunk -> CRLF
@@ -144,7 +137,7 @@ chunk_size_cr(_Bin, #state{length=undefined}) ->
 chunk_size_cr(<<"">>, S=#state{}) ->
     {more, {fun chunk_size_cr/2, S}};
 chunk_size_cr(<<"\n", Rest/binary>>, S=#state{length=0}) ->
-    last_chunk(Rest, maybe_buffer(<<"\n">>, S));
+    maybe_trailers(Rest, maybe_buffer(<<"\n">>, S));
 chunk_size_cr(<<"\n", Rest/binary>>, S=#state{}) ->
     chunk_data(Rest, maybe_buffer(<<"\n">>, S));
 chunk_size_cr(<<Char, _/binary>>, #state{}) ->
@@ -203,38 +196,18 @@ chunk_data_cr(<<"\n", Rest/binary>>, S=#state{length=0}) ->
 chunk_data_cr(Bin, #state{buffer=Buf, length=Len}) ->
     {error, {bad_chunk, {Len, [Buf,Bin]}}}.
 
-last_chunk(<<>>, S=#state{}) ->
-    %% Consider this done, due to possibly having only a bad CRLF
-    %% after the length, but not after the final chunk.
-    %{more, {fun last_chunk/2, S}};
-    %% This one adds no correction to the CRLF behavior and allows
-    %% to return partial last chunks. The downside is that it misses
-    %% the occasional CRLF that was split on a packet boundary
-    %{done, Buf, <<>>};
-    %% This one allows to go make sure that nothing is left on the buffer or
-    %% connection while maintaining data integrity.
+%% We're at the end of the stream, potentially, after
+%% a 0-length chunk. We wait forever on incomplete
+%% streams.
+maybe_trailers(<<>>, S=#state{}) ->
     {more, {fun maybe_trailers/2, S}};
-last_chunk(<<"\r", Rest/binary>>, S=#state{length=0}) ->
-    last_chunk_cr(Rest, maybe_buffer(<<"\r">>, S));
-last_chunk(Bin, S=#state{length=0, buffer=_Buf}) ->
-    %% Here we are lenient on a last chunk to allow all kinds of
-    %% dumb stuff to happen. Uncommenting the line makes for a
-    %% strict parser. This one here tolerates 0-length chunks halfway
-    %% through a stream and whatnot.
-    %{error, {bad_chunk, {0, [Buf,Bin]}}}.
-    %% Lax parser:
-    %{done, Buf, Bin}.
-    %% Move to trailers:
-    maybe_trailers(Bin, S).
+maybe_trailers(<<"\r", _/binary>> = Data, S=#state{}) ->
+    finalize(Data, S);
+maybe_trailers(OtherData, S=#state{}) ->
+    trailer(OtherData, S).
 
-trailer(_, #state{type=unchunked}) ->
-    %% Trailers cannot be supported in unchunked mode
-    error(unchunked_trailer);
-trailer(<<>>, S=#state{type=chunked}) ->
-    %% Data missing, we may have more trailers, or more garbage on
-    %% the line.
-    {more, {fun trailer/2, S}};
-trailer(Bin, S=#state{type=chunked}) ->
+%% Passthrough. header_name -> header_value -> switch
+trailer(Bin, S=#state{}) ->
     header_name(Bin, S).
 
 header_name(<<>>, S=#state{}) ->
@@ -297,38 +270,11 @@ header_value_quoted_string_esc(<<>>, S=#state{}) ->
 header_value_quoted_string_esc(<<Char, Rest/binary>>, S=#state{}) ->
     header_value_quoted_string(Rest, maybe_buffer(<<Char>>, S)).
 
-last_chunk_cr(<<>>, S=#state{}) ->
-    {more, {fun last_chunk_cr/2, S}};
-last_chunk_cr(<<"\n", Remainder/binary>>, S=#state{length=0}) ->
-    %% We're done! We ignore trailers and then return potentially bad data
-    %% because of that, until trailers *are* supported.
-    #state{buffer=Buf} = maybe_buffer(<<"\n">>, S),
-    {done, Buf, Remainder};
-last_chunk_cr(Bin, #state{length=0, buffer=Buf}) ->
-    %% Sorry, trailer!
-    {error, {bad_chunk, {0, [Buf,Bin]}}}.
-
-%% We're at the end of the stream, potentially, after
-%% a 0-length chunk.
-maybe_trailers(Data, S=#state{trailers=undefined}) ->
-    %% No trailers, skip;
-    finalize(Data, S);
-maybe_trailers(undefined, #state{buffer=Buf}) ->
-    %% Manually told us that no data was around, even with trailers.
-    {done, Buf, <<>>};
-maybe_trailers(OtherData, S=#state{trailers=true}) ->
-    trailer(OtherData, S).
-
-
-finalize(undefined, #state{buffer=Buf}) ->
-    {error, {bad_chunk, {last_crlf, Buf}}};
 finalize(<<"\r",Rest/binary>>, S=#state{}) ->
     finalize_cr(Rest, maybe_buffer(<<"\r">>, S));
 finalize(OtherData, #state{buffer=Buf}) ->
     %% That data may belong to anything, even other requests. Take
     %% no chances. We should have already checked for trailers at this point.
-    %{done, Buf, OtherData}.
-    % We instead go strict. We need more of that final data.
     {error, {bad_chunk, {last_crlf, [Buf,OtherData]}}}.
 
 finalize_cr(<<>>, S=#state{}) ->

--- a/src/vegur_client.erl
+++ b/src/vegur_client.erl
@@ -90,8 +90,7 @@
           last_packet_recv :: undefined | erlang:timestamp(),
           first_packet_sent :: undefined | erlang:timestamp(),
           last_packet_sent :: undefined | erlang:timestamp(),
-          log :: vegur_req_log:request_log(),
-          expect_trailers = false :: boolean()
+          log :: vegur_req_log:request_log()
 }).
 
 -type client() :: #client{}.
@@ -317,14 +316,7 @@ next_chunk(Client=#client{buffer=Buffer}, Cont) ->
     end.
 
 stream_chunk({Client, Cont}) -> stream_chunk(Client, stream_chunk, Cont);
-stream_chunk(Client=#client{expect_trailers=Trailers}) ->
-    %% Detect if we wait for trailers. Only do this for chunked transfers,
-    %% never for 'unchunked' ones as this doesn't carry over.
-    if Trailers ->
-            stream_chunk(Client, stream_chunk, trailers)
-     ; not Trailers ->
-            stream_chunk(Client, stream_chunk, undefined)
-    end.
+stream_chunk(Client=#client{}) -> stream_chunk(Client, stream_chunk, undefined).
 
 stream_unchunk({Client, Cont}) -> stream_chunk(Client, stream_unchunk, Cont);
 stream_unchunk(Client) -> stream_chunk(Client, stream_unchunk, undefined).
@@ -531,8 +523,6 @@ stream_header(Client=#client{state=State, buffer=Buffer,
                         true -> {error, cookie_length};
                         false -> Client
                     end;
-                <<"trailer">> ->
-                    Client#client{expect_trailers=true};
                 _ ->
                     Client
             end,

--- a/src/vegur_proxy.erl
+++ b/src/vegur_proxy.erl
@@ -84,12 +84,8 @@ send_body(_Method, Headers, Body, _Path, _Url, Req, BackendClient) ->
     end.
 
 %% depending on the type of body, set the right streaming function
-choose_body_stream_type(Headers, chunked) ->
-    InitState = case has_trailers(Headers) of
-        false -> undefined;
-        true -> trailers
-    end,
-    {fun decode_chunked/2, {InitState, InitState, 0}};
+choose_body_stream_type(_Headers, chunked) ->
+    {fun decode_chunked/2, {undefined, undefined, 0}};
 choose_body_stream_type(_Headers, BodyLen) ->
     {fun decode_raw/2, {0, BodyLen}}.
 
@@ -708,9 +704,6 @@ add_connection_upgrade_header(Hdrs) ->
 add_via(Headers) ->
     Via = vegur_utils:get_via_value(),
     vegur_utils:add_or_append_header(<<"via">>, Via, Headers).
-
-has_trailers(Headers) ->
-    lists:keymember(<<"trailer">>, 1, Headers).
 
 %% When sending data in passive mode, it is usually impossible to be notified
 %% of connections being closed. For this to be done, we need to poll the socket


### PR DESCRIPTION
Chuncks currently can terminate in a `0\r\n` on a packet boundary.
When that happens, we poll for data on the pipe once, and then give up,
sending the last terminal chunk that way.

This however causes problems on strict servers (and clients) that end up
waiting for data that never comes down the line.

This pull request changes things so that Vegur will wait on a `0\r\n`
and keep polling for a final `\r\n` without giving up until it gets it
(or garbage on the line).

Specific changes in behaviour:
- a new error value for `bad_chunk` has been added in the form of
  `{bad_chunk, {last_crlf, _Buffer}}` and will need to be handled by
  libraries using Vegur
- A request without the `\r\n` missing at the end will now wait for the
  default amount of time before a timeout (defaults at 55s)
- The server will receive partially sent chunks that may still hang
  the way they were doing it before, but will return a different
  error code, blaming the client instead of the server
- If garbage follows the bad chunk (trailers without the header, next
  request), the request will explicitly fail with a bad_chunk error;
  the server may or may not have the time to see content coming back
  up, and should never have the time to send a response.
- In the case above where the server sends an early response, the
  current state of thing is that this response is buffered and won't
  show up.
- trailers are still only supported if the trailers header is there.
  In the case the header wasn't included, we change from forwarding an
  incomplete chunk stream to erroring out.
