### PR TITLE
Expand callback for custom headers

### DIFF
--- a/src/vegur_interface.erl
+++ b/src/vegur_interface.erl
@@ -87,9 +87,11 @@
       Upstream :: upstream(),
       HandlerState :: handler_state().
 
--callback additional_headers(Logs, HandlerState) ->
+-callback additional_headers(Direction, Logs, Upstream, HandlerState) ->
     {HeadersToAddOrReplace, HandlerState} when
+      Direction :: upstream | downstream,
       Logs :: vegur_req_log:request_log(),
+      Upstream :: upstream(),
       HeadersToAddOrReplace :: [{binary(), iodata()}],
       HandlerState :: handler_state().
 

--- a/src/vegur_proxy.erl
+++ b/src/vegur_proxy.erl
@@ -273,11 +273,17 @@ relay(Code, Status, HeadersRaw, Req, Client) ->
     %% in batch or directly.
     {Headers, Req1} = case connection_type(Code, Req, Client) of
         {keepalive, Req0} ->
-            {add_connection_keepalive_header(response_headers(HeadersRaw)),
-             Req0};
+            vegur_utils:add_interface_headers(
+                downstream,
+                add_connection_keepalive_header(response_headers(HeadersRaw)),
+                Req0
+            );
         {close, Req0} ->
-            {add_connection_close_header(response_headers(HeadersRaw)),
-             Req0}
+            vegur_utils:add_interface_headers(
+                downstream,
+                add_connection_close_header(response_headers(HeadersRaw)),
+                Req0
+            )
     end,
     case vegur_client:body_type(Client) of
         {content_size, N} when N =< ?UPSTREAM_BODY_BUFFER_LIMIT ->

--- a/src/vegur_proxy_middleware.erl
+++ b/src/vegur_proxy_middleware.erl
@@ -157,17 +157,14 @@ add_proxy_headers(Headers, Req) ->
     {Headers4, Req4} = add_connect_time(Headers3, Req3),
     {Headers5, Req5} = add_start_time(Headers4, Req4),
     {Headers6, Req6} = add_total_route_time(Headers5, Req5),
-    add_interface_headers(Headers6, Req6).
+    add_upstream_interface_headers(Headers6, Req6).
 
-add_interface_headers(Headers, Req) ->
+add_upstream_interface_headers(Headers, Req) ->
     {Log, Req1} = cowboy_req:meta(logging, Req),
-    {InterfaceModule, HandlerState, Req2} = vegur_utils:get_interface_module(Req1),
-    {InterfaceHeaders, HandlerState1} = InterfaceModule:additional_headers(Log, HandlerState),
-    Req3 = vegur_utils:set_handler_state(HandlerState1, Req2),
-    FinalHeaders = vegur_utils:add_or_replace_headers(InterfaceHeaders, Headers),
+    {Headers1, Req2} = vegur_utils:add_interface_headers(upstream, Headers, Req1),
     Log1 = vegur_req_log:stamp(headers_formatted, Log),
-    Req4 = cowboy_req:set_meta(logging, Log1, Req3),
-    {FinalHeaders, Req4}.
+    Req3 = cowboy_req:set_meta(logging, Log1, Req2),
+    {Headers1, Req3}.
 
 add_start_time(Headers, Req) ->
     {Time, Req1} = vegur_req:start_time(Req),


### PR DESCRIPTION
Vegur currently defines the callback
`additional_headers(Log, HandlerState)` which allows the addition of
arbitrary headers when going to the backend (upstream).

This patches expands the callback so vegur passes two more arguments:
1. the direction (upstream / downstream)
2. the vegur_req object (which is a wrapper around cowboy_req) named
   `Connection` when passed to the callback module

The new callback is now
`additional_headers(upstream|downstream, Log, Connection, HState)`
which lets the router sitting on top of vegur set its own headers
when responding to a client.

The headers set are merged by the same mechanism they were before.
