### PR TITLE
make vegur dialyzer clean in hermes

### DIFF
--- a/src/vegur_interface.erl
+++ b/src/vegur_interface.erl
@@ -15,7 +15,7 @@
                 {route_time|connect_time|total_time, ms()}.
 -type stats() :: [stat()]|[].
 -type feature() :: deep_continue | peer_port.
--opaque upstream() :: cowboy_req:req().
+-type upstream() :: cowboy_req:req().
 
 -export_type([domain/0,
               domain_group/0,
@@ -52,7 +52,7 @@
 -callback checkout_service(DomainGroup, Upstream, HandlerState) ->
     {service, service(), Upstream, HandlerState}|
     {error, CheckoutError, Upstream, HandlerState} when
-      CheckoutError :: atom(),
+      CheckoutError :: atom()|tuple(),
       DomainGroup :: domain_group(),
       Upstream :: upstream(),
       HandlerState :: handler_state().

--- a/src/vegur_stub.erl
+++ b/src/vegur_stub.erl
@@ -78,7 +78,7 @@ lookup_domain_name(_Domain, Upstream, HandlerState) ->
 -spec checkout_service(DomainGroup, Upstream, HandlerState) ->
                               {service, Service, Upstream, HandlerState} |
                               {error, CheckoutError, Upstream, HandlerState} when
-      CheckoutError :: atom(),
+      CheckoutError :: atom()|tuple(),
       DomainGroup :: vegur_interface:domain_group(),
       Service :: vegur_interface:service(),
       HandlerState :: vegur_interface:handler_state(),


### PR DESCRIPTION
- widen an error type
- make the opaque upstream type a regular type

note that I tried to keep the type opaque, but there were just too many places where we use it from cowboy functions in hermes.  making it fully abstract is a much bigger job (if it's possible at all given that we're defining some cowboy middleware).
