### PR TITLE
additions for i99 reporting

### DIFF
--- a/src/vegur_proxy.erl
+++ b/src/vegur_proxy.erl
@@ -95,7 +95,7 @@ negotiate_continue(Body, Req, BackendClient) ->
     negotiate_continue(Body, Req, BackendClient, Timeout).
 
 negotiate_continue(_, _, _, Timeout) when Timeout =< 0 ->
-    {error, upstream, Timeout};
+    {error, upstream, timeout};
 negotiate_continue(Body, Req, BackendClient, Timeout) ->
     %% In here, we must await the 100 continue from the BackendClient
     %% *OR* wait until cowboy (front-end) starts sending data.

--- a/src/vegur_stub.erl
+++ b/src/vegur_stub.erl
@@ -213,7 +213,17 @@ error_page(expectation_failed, _DomainGroup, Upstream, HandlerState) ->
     {{417, [], <<>>}, Upstream, HandlerState};
 error_page({upstream, closed}, _DomainGroup, Upstream, HandlerState) ->
     {{503, [], <<>>}, Upstream, HandlerState};
+error_page({upstream, etimedout}, _DomainGroup, Upstream, HandlerState) ->
+    {{503, [], <<>>}, Upstream, HandlerState};
+error_page({upstream, enotconn}, _DomainGroup, Upstream, HandlerState) ->
+    {{503, [], <<>>}, Upstream, HandlerState};
 error_page({downstream, closed}, _DomainGroup, Upstream, HandlerState) ->
+    {{503, [], <<>>}, Upstream, HandlerState};
+error_page({downstream, etimedout}, _DomainGroup, Upstream, HandlerState) ->
+    {{503, [], <<>>}, Upstream, HandlerState};
+error_page({downstream, enotconn}, _DomainGroup, Upstream, HandlerState) ->
+    {{503, [], <<>>}, Upstream, HandlerState};
+error_page({downstream, econnrefused}, _DomainGroup, Upstream, HandlerState) ->
     {{503, [], <<>>}, Upstream, HandlerState};
 error_page({downstream, timeout}, _DomainGroup, Upstream, HandlerState) ->
     {{503, [], <<>>}, Upstream, HandlerState};


### PR DESCRIPTION
- change 100 continue timeouts to return an atom instead 0
- add more clauses to error_page in vegur stub as documentation for
  potential returns that will have to be covered

TODO: add more types

Not sure that this is complete.  @ferd, you said: "`vegur_interface` and `vegur_stub` should be updated to reflect these new error codes in types and documentation."  Does this cover everything that you were thinking about?  The types are all `term()` right now, but I can also make a stab at getting them added, if that's desirable.
