### PR TITLE
Expose the response headers through vegur_req

### DIFF
--- a/src/vegur_proxy_middleware.erl
+++ b/src/vegur_proxy_middleware.erl
@@ -73,7 +73,8 @@ read_backend_response(Req, #state{backend_client=BackendClient}=State) ->
     end.
 
 handle_backend_response(Code, Status, RespHeaders, Req, State) ->
-    {Type, Req2} = cowboy_req:meta(request_type, Req, []),
+    Req1 = cowboy_req:set_meta(response_headers, RespHeaders, Req),
+    {Type, Req2} = cowboy_req:meta(request_type, Req1, []),
     case lists:sort(Type) of
         [] ->
             http_request(Code, Status, RespHeaders, Req2, State);

--- a/src/vegur_req.erl
+++ b/src/vegur_req.erl
@@ -30,6 +30,7 @@
          ,raw_path/1
          ,header/2
          ,response_code/1
+         ,response_headers/1
         ]).
 
 -spec start_time(Req) -> {StartTime, Req} when
@@ -170,6 +171,12 @@ header(Key, Req) ->
       Code :: non_neg_integer().
 response_code(Req) ->
     cowboy_req:meta(response_code, Req, <<>>).
+
+-spec response_headers(Req) -> {[{iodata(), iodata()}], Req} when
+    Req :: cowboy_req:req().
+response_headers(Req) ->
+    cowboy_req:meta(response_headers, Req, []).
+
 
 %% Internal
 timestamp_diff(FromKey, ToKey, Req) ->

--- a/test/vegur_dyno.erl
+++ b/test/vegur_dyno.erl
@@ -21,8 +21,7 @@ init(_Transport, Req, Opts) ->
 
 handle(Req, Opts) ->
     F = proplists:get_value(in_handle, Opts, fun(R) -> R end),
-    F(Req),
-    {ok, Req, Opts}.
+    {ok, F(Req), Opts}.
 
 terminate(_Reason, _Req, _State) ->
     ok.


### PR DESCRIPTION
Since we enabled to set headers on responses from the dyno to the
client, I figure it would also be useful to enable the headers set by
the client to be visible to the routing layer.

The headers are unmodified, and rather than replicating the existing
`cookie(Key, Req)` mechanism, this one returns an unmodified resource.

This is specifically because the server can set some headers multiple
time, with cases such as `Set-Cookie: ...` being there once per header
(this issue doesn't exist client-side because the `Cookie` header is
meant to merge all values in one header).
