### PR TITLE
Support proper timeout options

### DIFF
--- a/src/vegur.app.src
+++ b/src/vegur.app.src
@@ -21,7 +21,7 @@
           ,{request_id_max_size, 200}
           ,{idle_timeout, 55} % seconds
           ,{downstream_connect_timeout, 5000} % milliseconds
-          ,{downstream_timeout, 30} % seconds
+          ,{downstream_first_read_timeout, 30} % seconds
           ,{client_tcp_buffer_limit, 1048576} % 1024 * 1024 bytes
           ,{max_client_status_length, 8192} % bytes
           ,{max_client_header_length, 524288} % bytes (512k)

--- a/test/timeout_handler.erl
+++ b/test/timeout_handler.erl
@@ -1,0 +1,18 @@
+-module(timeout_handler).
+-compile(export_all).
+
+init({_Any, http}, Req, State) ->
+    {ok, Req, State}.
+
+handle(Req, [first]) ->
+    timer:sleep(infinity),
+    {ok, Req, [first]};
+handle(Req, [other]) ->
+    {{Trans, Sock}, Req2} = vegur_utils:raw_cowboy_socket(Req),
+    Trans:send(Sock, "HTTP/1.1 200 O"), % partial data
+    timer:sleep(infinity),
+    {ok, Req2, [other]}.
+
+terminate(_Reason, _Req, _State) ->
+    ok.
+


### PR DESCRIPTION
The requirements to work as a Heroku proxy specify:

> An application has an initial 30 second window to respond with a single
> byte back to the client. However, each byte transmitted thereafter
> (either received from the client or sent by your application) resets a
> rolling 55 second window. If no data is sent during the 55 second
> window, the connection will be terminated.

This patch makes it so there is a proper distinction between the first
recv and the follow-up ones.

This change is backwards incompatible as it renames a configuration
variable and changes the vegur_client record structure.
