### PR TITLE
Enable TCP_DEFER_ACCEPT by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ The configuration can be passed following the standard Erlang/OTP application lo
   header line, in bytes. Defaults to `524288`, or 512kb.
 - `{max_client_cookie_length, pos_integer()}`: Maximal size of a cookie in a
   response, in bytes. Defaults to `8192`.
+- `{extra_socket_options, [gen_tcp:option()]}`: Allows to set additional
+  TCP options useful for configuration (such as `nodelay` or `raw` options).
 
 ### Server Configuration
 

--- a/src/vegur.app.src
+++ b/src/vegur.app.src
@@ -26,5 +26,6 @@
           ,{max_client_status_length, 8192} % bytes
           ,{max_client_header_length, 524288} % bytes (512k)
           ,{max_client_cookie_length, 8192} % bytes
+          ,{extra_socket_options, []} % options to be passed to TCP ports
          ]}
  ]}.

--- a/src/vegur.erl
+++ b/src/vegur.erl
@@ -129,13 +129,15 @@ start(Type, Ref, Port, Interface, Config) ->
 start_listener(http, Ref, Port, Acceptors, MaxConnections, Config) ->
     cowboyku:start_http(Ref, Acceptors,
                         [{port, Port},
-                         {max_connections, MaxConnections}],
+                         {max_connections, MaxConnections}
+                         | extra_socket_options()],
                         merge_options(defaults(), Config));
 start_listener(proxy, Ref, Port, Acceptors, MaxConnections, Config) ->
     ranch:start_listener(Ref, Acceptors,
                          ranch_proxy,
                          [{port, Port},
-                          {max_connections, MaxConnections}],
+                          {max_connections, MaxConnections}
+                          | extra_socket_options()],
                          cowboyku_protocol,
                          merge_options(defaults(), Config)).
 
@@ -152,6 +154,9 @@ merge_options([{Key, _}=DefaultPair|Rest], Config) ->
         false ->
             merge_options(Rest, Config++[DefaultPair])
     end.
+
+extra_socket_options() ->
+    vegur_utils:config(extra_socket_options, []).
 
 defaults() ->
     [{middlewares, [vegur_midjan_middleware]}


### PR DESCRIPTION
This is non-portable as an option, but allows the linux kernel to delay
communicating an 'accept' to userspace until a PSH packet has made it
down the line and data is awaiting for us.  This allows to optimize the
whole flow so that the kernel handles the 3-way handshake entirely. So
rather than going:

```
client       kernel        erlang
  |----SYN----> |             |
  |<--SYN+ACK-- |             |
  |----ACK----> | ----ACK---->| (accept returns)
  |             |       [call recv, deschedules]
  |----PSH----> | ----PSH---->|
                       [wakes up, recv returns]
```

This option allows to go:

```
client       kernel        erlang
  |----SYN----> |            |
  |<--SYN+ACK-- |            |
  |----ACK----> |            |
  |----PSH----> | ----PSH----> (accept returns)
                         [recv returns]
```

Saving on resources the entire way through.  We have hardcoded the DEFER
timeout to 55 seconds, in line with other defaults.
