### PR TITLE
Export reps_left/0

### DIFF
--- a/src/vegur_proxy.erl
+++ b/src/vegur_proxy.erl
@@ -2,7 +2,6 @@
 
 -define(UPSTREAM_BODY_BUFFER_LIMIT, 65536). % 64kb, in bytes
 -define(DOWNSTREAM_BODY_BUFFER_LIMIT, 65536). % 64kb, in bytes
--define(POLL_INCREMENTS, 1000).
 
 -export([backend_connection/1
          ,send_headers/7


### PR DESCRIPTION
Export `reps_left/0` mostly for mocking.

Open to better ideas (but I don't think to much macro fun is a better idea).

This is needed to be able to test idle connections in Hermes.
