### PR TITLE
Generalize error type

### DIFF
--- a/src/vegur_interface.erl
+++ b/src/vegur_interface.erl
@@ -69,7 +69,7 @@
       HandlerState :: handler_state().
 
 -callback lookup_domain_name(Domain, Upstream, HandlerState) ->
-    {error, not_found, Upstream, HandlerState} |
+    {error, atom(), Upstream, HandlerState} |
     {redirect, Reason, DomainGroup, Domain, Upstream, HandlerState} |
     {ok, DomainGroup, Upstream, HandlerState} when
       Domain :: binary(),


### PR DESCRIPTION
Use `atom()` instead of fixed `not_found` error type in
`vegur_interface:lookup_domain_name/3`. This allows the behaviour
implementation more freedom in which errors it returns.