### PR TITLE
Enable SO_REUSEADDR for backend connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 install: "true" # don't let travis run get-deps
 script: "./rebar3 do update, ct, dialyzer"
 otp_release:
-- 19.0
+- 19.0.3
 - 18.3
 notifications:
   email: false

--- a/src/vegur_proxy.erl
+++ b/src/vegur_proxy.erl
@@ -96,7 +96,8 @@ backend_connection({IpAddress, Port}) ->
 
 start_backend_connection({IpAddress, Port}) ->
     TcpBufSize = vegur_utils:config(client_tcp_buffer_limit),
-    {ok, Client} = vegur_client:init([{packet_size, TcpBufSize},
+    {ok, Client} = vegur_client:init([{reuseaddr, true},
+                                      {packet_size, TcpBufSize},
                                       {recbuf, TcpBufSize}]),
     case vegur_client:connect(ranch_tcp, IpAddress, Port, Client) of
         {ok, Client1} ->


### PR DESCRIPTION
The Erlang TCP stack translates a TCP `connect` call to a set of
standard operations in the linux kernel:

- open a socket
- bind(Socket, "0.0.0.0", 0)
- connect(Socket, Ip, Port)

Surprisingly enough, that `bind` call always happens and has the
unfortunate side-effect of picking one of the currently unassigned ports
in the ephemeral port range.

The negative aspect here is that despite TCP identifying connections by
4-tuple (`{LocalIp, LocalPort, RemoteIp, RemotePort}`), which would let
us use the entire ephemeral port range for each remote `IP:Port` combo,
the way Erlang uses them forces us to only the ephemeral port range due
to the `bind` call's limitations.

By passing in `SO_REUSEADDR` (or in the case of Erlang, `{reuseaddr,
true}`) we allow the bind call to reuse the ephemeral port. The check
will then be done by the connect syscall to see if the value is valid or
not (against the 4-tuple mapping). If the value is not valid, the error
returned will then be the POSIX code for `EADDRNOTAVAIL` (or just
`eaddrnotavail` in Erlang).

This frees up the full port range and isolates one endpoint being
overloaded from others suffering the same fate.