### PR TITLE
Remove X-Forwarded-Host headers

### DIFF
--- a/src/vegur_headers.erl
+++ b/src/vegur_headers.erl
@@ -91,7 +91,9 @@ response_headers(Headers) ->
                 ]).
 
 delete_host_header(Hdrs) ->
-    vegur_utils:delete_all_headers(<<"host">>, Hdrs).
+    NewHdrs = vegur_utils:delete_all_headers(<<"host">>, Hdrs),
+    %% And now for safety of proxied apps:
+    vegur_utils:delete_all_headers(<<"x-forwarded-host">>, NewHdrs).
 
 delete_content_length_header(Hdrs) ->
     vegur_utils:delete_all_headers(<<"content-length">>, Hdrs).

--- a/test/vegur_roundtrip_SUITE.erl
+++ b/test/vegur_roundtrip_SUITE.erl
@@ -50,7 +50,7 @@ groups() -> [{continue, [], [
                 delete_hop_by_hop, response_cookie_limits,
                 response_header_line_limits, response_status_limits,
                 via, via_chain, bad_status, preserve_case, header_order,
-                host_nofold, host_conflict
+                host_nofold, host_conflict, drop_forwarded_host
              ]},
              {http_1_0, [], [
                 advertise_1_1, conn_close_default, conn_keepalive_opt,
@@ -1002,6 +1002,31 @@ host_conflict(Config) ->
     %% Without making it to the server, we get a 400 back. for bad request
     {ok, Resp} = gen_tcp:recv(Client, 0, 1000),
     {match, _} = re:run(Resp, "400").
+
+drop_forwarded_host(Config) ->
+    %% Drop the X-Forwarded-Host headers because we never cared about them
+    %% before and some apps we proxy too can get nasty injection attacks from
+    %% them.
+    IP = ?config(server_ip, Config),
+    Port = ?config(proxy_port, Config),
+    Req =
+    "POST / HTTP/1.1\r\n"
+    "Host: "++domain(Config)++"\r\n"
+    "x-forwArded-Host: "++domain(Config)++"\r\n"
+    "Content-Type: text/plain\r\n"
+    "X-Forwarded-Host: "++domain(Config)++"\r\n"
+    "\r\n"
+    "0123456789",
+    %% Open the server to listening. We then need to send data for the
+    %% proxy to get the request and contact a back-end
+    Ref = make_ref(),
+    start_acceptor(Ref, Config),
+    {ok, Client} = gen_tcp:connect(IP, Port, [{active,false},list],1000),
+    ok = gen_tcp:send(Client, Req),
+    Server = get_accepted(Ref),
+    %% receive the request, content-length of 10 is there once only.
+    {ok, Proxied} = gen_tcp:recv(Server, 0, 1000),
+    nomatch = re:run(Proxied, "[xX]-[fF]orwarded-[hH]ost:", [{capture, all}, global]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% HTTP 1.0 BEHAVIOUR %%%

--- a/test/vegur_roundtrip_SUITE.erl
+++ b/test/vegur_roundtrip_SUITE.erl
@@ -1005,7 +1005,7 @@ host_conflict(Config) ->
 
 drop_forwarded_host(Config) ->
     %% Drop the X-Forwarded-Host headers because we never cared about them
-    %% before and some apps we proxy too can get nasty injection attacks from
+    %% before and some apps we proxy to can get nasty injection attacks from
     %% them.
     IP = ?config(server_ip, Config),
     Port = ?config(proxy_port, Config),
@@ -1024,9 +1024,9 @@ drop_forwarded_host(Config) ->
     {ok, Client} = gen_tcp:connect(IP, Port, [{active,false},list],1000),
     ok = gen_tcp:send(Client, Req),
     Server = get_accepted(Ref),
-    %% receive the request, content-length of 10 is there once only.
+    %% receive the request, x-forwarded-host is no longer there.
     {ok, Proxied} = gen_tcp:recv(Server, 0, 1000),
-    nomatch = re:run(Proxied, "[xX]-[fF]orwarded-[hH]ost:", [{capture, all}, global]).
+    nomatch = re:run(Proxied, "x-forwarded-host:", [{capture, all}, global, caseless]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% HTTP 1.0 BEHAVIOUR %%%


### PR DESCRIPTION
Some backend applications vegur is used to proxy through may give a
higher priority to `X-Forwarded-Host` than `Host` as a header, and this
can be used in part of attempts of setting up cache poisoning.

This patch makes sure that the header is unset and not passed to backend
applications.