### PR TITLE
Add Travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vegur
 
+[![Build Status](https://travis-ci.org/heroku/vegur.svg?branch=master)](https://travis-ci.org/heroku/vegur)
+
 Heroku's proxy library based on a forked Cowboy frontend (Cowboyku). This
 library handles proxying in Heroku's routing stack
 


### PR DESCRIPTION
Makes it more obvious that the project has CI set up and provides quicker access to the latest test run for comparison to local results (I have test failures locally on master, it wasn't initially obvious if they were expected failures).