### PR TITLE
Fix unused variable warnings in vegur_websockets_backend.erl

### DIFF
--- a/test/vegur_websockets_backend.erl
+++ b/test/vegur_websockets_backend.erl
@@ -36,10 +36,10 @@
 -export([websocket_info/3]).
 -export([websocket_terminate/3]).
 
-init({tcp, http}, Req, Opts) ->
+init({tcp, http}, _Req, _Opts) ->
     {upgrade, protocol, cowboyku_websocket}.
 
-websocket_init(TransportName, Req, _Opts) ->
+websocket_init(_TransportName, Req, _Opts) ->
     {ok, Req, undefined_state}.
 
 websocket_handle({text, Msg}, Req, State) ->


### PR DESCRIPTION
```
test/vegur_websockets_backend.erl:39: Warning: variable 'Opts' is unused
test/vegur_websockets_backend.erl:39: Warning: variable 'Req' is unused
test/vegur_websockets_backend.erl:42: Warning: variable 'TransportName' is unused
```

Fixes #164.