### PR TITLE
Switch from the deprecated now() to timestamp()

### DIFF
--- a/test/bench.erl
+++ b/test/bench.erl
@@ -61,7 +61,7 @@ make_chunks(N, Len, ChunkLen) ->
 
 
 make_chunked(Len, ChunkLen) ->
-    rand:seed(now()),
+    rand:seed(erlang:timestamp()),
     Chunks =
         [make_chunk(ChunkLen)
          || _ <- lists:seq(1, Len)],

--- a/test/vegur_req_log_SUITE.erl
+++ b/test/vegur_req_log_SUITE.erl
@@ -35,7 +35,7 @@
 all() -> [merge].
 
 init_per_testcase(merge, Config) ->
-    Logs = [vegur_req_log:new(now()) || _ <- lists:seq(1,5)],
+    Logs = [vegur_req_log:new(erlang:timestamp()) || _ <- lists:seq(1,5)],
     [{logs, list_to_tuple(Logs)} | Config].
 
 end_per_testcase(merge, _Config) ->


### PR DESCRIPTION
Since `now()` is deprecated:
http://erlang.org/doc/man/erlang.html#now-0

...in favour of `timestamp()`:
http://erlang.org/doc/man/erlang.html#timestamp-0

Fixes #165.