### PR TITLE
Add custom non-permanent redirects

### DIFF
--- a/src/vegur_interface.erl
+++ b/src/vegur_interface.erl
@@ -72,9 +72,11 @@
 -callback lookup_domain_name(Domain, Upstream, HandlerState) ->
     {error, atom(), Upstream, HandlerState} |
     {redirect, Reason, DomainGroup, Domain, Upstream, HandlerState} |
+    {redirect, Code, Reason, DomainGroup, Domain, Upstream, HandlerState} |
     {ok, DomainGroup, Upstream, HandlerState} when
       Domain :: binary(),
       Reason :: atom(),
+      Code :: 300..399,
       DomainGroup :: domain_group(),
       Upstream :: upstream(),
       HandlerState :: handler_state().


### PR DESCRIPTION
A 301 is permanent and some usages may benefit from something other than
that. For example, redirections within a single domain (to a login page) or for some
temporary downtime.

This change is fully backwards compatible. I have not added tests yet for this one since
the change was rather trivial, but I can always add some if you'd like me to.