### PR TITLE
Make Vegur's dynamic config relup-safe

### DIFF
--- a/src/vegur.erl
+++ b/src/vegur.erl
@@ -134,7 +134,7 @@ default_middlewares() ->
       Key :: atom(),
       Val :: term().
 set_config(Key, Val) ->
-    application:set_env(vegur, Key, Val).
+    application:set_env(vegur_dynamic, Key, Val).
 
 -spec defaults() -> [proplists:property()].
 defaults() ->


### PR DESCRIPTION
When upgrading a release through a relup, the SASL release_handler
process goes through the application's config, and resets all of those
of currently running applications. The new value is based off, in order:

1. command line arguments
2. the values found in the current (new) sys.config
3. the values found in the .app file's env tuple

All the values that were added and changed dynamically are dropped.

This changeset forces a separation between dynamic and static
configuration values. Static configuration values are set in the
'vegur' app and can be changed by sys.config and others. Dynamic
configuration values are set in the 'vegur_dynamic' app name -- since no
such app exists, they are safely ignored by SASL.

To keep the change backwards compatible for all usages, this patch
therefore makes a two-tiered config lookup:

- check if a dynamic value exists at first (it has been set dynamically
  somewhere and is therefore important)
- if it is not found, look for the static one that is a safe immutable
  (per version) default to use.

This may come at a slight performance hit (two lookups instead of one)
for some static values, but this has never been a bottleneck compared to
say, CamelCasing headers, and without this change, no live code upgrades
with relups can be performed in a system relying on vegur.