### PR TITLE
Handle temporary buffer right on backend close

### DIFF
--- a/src/vegur_proxy.erl
+++ b/src/vegur_proxy.erl
@@ -639,7 +639,7 @@ stream_request(Buffer, Req, Client, DownBuffer, N) ->
                 {error, Err} ->
                     {error, upstream, Err}
             end;
-        {error, closed} when byte_size(DownBuffer) > 0 ->
+        {error, closed} when byte_size(NewDownBuffer) > 0 ->
             %% we have a buffer accumulated, it's likely an early response came
             %% while streaming the body. We must however force the connection
             %% to be closed because we won't wait until the full body is read.


### PR DESCRIPTION
The calculation to know if we needed to forward data from the back-end
to the front-end only used the buffer accumulated prior to the
connection being closed or reset. When all the response data fit in one
packet received right before the termination, the response would be
invisible and ignored.

This patch considers both the prior and the most recent buffer to be
non-empty, ensuring that on the short span, the response is actually
forwarded. `NewDownBuffer` contains `DownBuffer`, so checking only the
former contains the latter.

This has been a long-standing very subtle bug!